### PR TITLE
Fix/README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ dependencies {
   compile "im.ene.toro2:toro-ext-exoplayer:${toroVersion}"
   
   // include extension for Legacy MediaPlayer (Toro is included already)
-  compile "im.ene.toro2:oro-ext-mediaplayer:${toroVersion}"
+  compile "im.ene.toro2:toro-ext-mediaplayer:${toroVersion}"
 }
 ```
 


### PR DESCRIPTION
Changed:
   compile "im.ene.toro2:oro-ext-mediaplayer:${toroVersion}"
to
  compile "im.ene.toro2:toro-ext-mediaplayer:${toroVersion}"