### PR TITLE
Migrate to ExoPlayer 2.6.0

### DIFF
--- a/app/src/main/java/im/ene/toro/sample/common/LoopingExoPlayerViewHelper.java
+++ b/app/src/main/java/im/ene/toro/sample/common/LoopingExoPlayerViewHelper.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.ParserException;
+import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.ui.SimpleExoPlayerView;
 import im.ene.toro.ToroPlayer;
@@ -62,7 +63,7 @@ public final class LoopingExoPlayerViewHelper extends ToroPlayerHelper {
     mediaSourceBuilder = new LoopingMediaSourceBuilder(context, mediaUri);
   }
 
-  public final void setEventListener(ExoPlayer.EventListener eventListener) {
+  public final void setEventListener(Player.EventListener eventListener) {
     this.internalListener.setDelegate(eventListener);
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
   androidVersion = 26
   buildToolVersion = '26.0.2'
   supportLibraryVersion = '27.0.1'
-  exoPlayer2Version = 'r2.5.4'
+  exoPlayer2Version = '2.6.0'
   minSupportSDKVersion = 16
 }
 

--- a/toro-core/src/main/java/im/ene/toro/exoplayer/ExoPlayerHelper.java
+++ b/toro-core/src/main/java/im/ene/toro/exoplayer/ExoPlayerHelper.java
@@ -22,6 +22,7 @@ import android.support.annotation.FloatRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.widget.Toast;
+
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.DefaultRenderersFactory;
 import com.google.android.exoplayer2.DefaultRenderersFactory.ExtensionRendererMode;
@@ -54,14 +55,16 @@ import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory;
 import com.google.android.exoplayer2.util.Util;
-import im.ene.toro.R;
-import im.ene.toro.ToroUtil;
-import im.ene.toro.media.DrmMedia;
-import im.ene.toro.media.PlaybackInfo;
+
 import java.net.CookieManager;
 import java.net.CookiePolicy;
 import java.util.ArrayList;
 import java.util.UUID;
+
+import im.ene.toro.R;
+import im.ene.toro.ToroUtil;
+import im.ene.toro.media.DrmMedia;
+import im.ene.toro.media.PlaybackInfo;
 
 import static com.google.android.exoplayer2.drm.UnsupportedDrmException.REASON_UNSUPPORTED_SCHEME;
 
@@ -389,7 +392,7 @@ public final class ExoPlayerHelper {
       }
     }
 
-    @Override public void onPositionDiscontinuity() {
+    @Override public void onPositionDiscontinuity(int reason) {
       if (needRetrySource) {
         // This will only occur if the user has performed a seek whilst in the error playerState. Update the
         // resume position so that if the user then retries, playback will resume from the position to
@@ -399,7 +402,7 @@ public final class ExoPlayerHelper {
       int count;
       if (eventListeners != null && (count = eventListeners.size()) > 0) {
         for (int i = count - 1; i >= 0; i--) {
-          eventListeners.get(i).onPositionDiscontinuity();
+          eventListeners.get(i).onPositionDiscontinuity(reason);
         }
       }
     }
@@ -409,6 +412,24 @@ public final class ExoPlayerHelper {
       if (eventListeners != null && (count = eventListeners.size()) > 0) {
         for (int i = count - 1; i >= 0; i--) {
           eventListeners.get(i).onPlaybackParametersChanged(parameters);
+        }
+      }
+    }
+
+    @Override public void onShuffleModeEnabledChanged(boolean shuffleModeEnabled) {
+      int count;
+      if (eventListeners != null && (count = eventListeners.size()) > 0) {
+        for (int i = count - 1; i >= 0; i--) {
+          eventListeners.get(i).onShuffleModeEnabledChanged(shuffleModeEnabled);
+        }
+      }
+    }
+
+    @Override public void onSeekProcessed() {
+      int count;
+      if (eventListeners != null && (count = eventListeners.size()) > 0) {
+        for (int i = count - 1; i >= 0; i--) {
+          eventListeners.get(i).onSeekProcessed();
         }
       }
     }
@@ -512,8 +533,16 @@ public final class ExoPlayerHelper {
       if (this.delegate != null) this.delegate.onPlayerError(error);
     }
 
-    @Override public void onPositionDiscontinuity() {
-      if (this.delegate != null) this.delegate.onPositionDiscontinuity();
+    @Override public void onPositionDiscontinuity(int reason) {
+      if (this.delegate != null) this.delegate.onPositionDiscontinuity(reason);
+    }
+
+    @Override public void onShuffleModeEnabledChanged(boolean shuffleModeEnabled) {
+      if (this.delegate != null) this.delegate.onShuffleModeEnabledChanged(shuffleModeEnabled);
+    }
+
+    @Override public void onSeekProcessed() {
+      if (this.delegate != null) this.delegate.onSeekProcessed();
     }
 
     @Override public void onPlaybackParametersChanged(PlaybackParameters playbackParameters) {


### PR DESCRIPTION
## Summary
`ExoPlayer.EventListener` is deprecated in 2.6.0. This PR will upgrade Toro’s sample app to use 2.6.0 and the new `Player.EventListener` interface.