### PR TITLE
Feature: PlayerSelector for Individual Players

### DIFF
--- a/toro-core/src/main/java/im/ene/toro/SinglePlayerSelector.java
+++ b/toro-core/src/main/java/im/ene/toro/SinglePlayerSelector.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017 Thiago Ricieri, thiago.ricieri@gmail.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package im.ene.toro;
+
+import android.support.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import im.ene.toro.widget.Container;
+
+/**
+ * @author thiagoricieri | 12/11/17.
+ *
+ *         SinglePlayerSelector is a convenient class to provide a single {@link PlayerSelector}
+ *         to {@link Container}, ideal for Recycler Views that are setup to not play
+ *         video automatically.
+ *
+ *         1. Setup the container view to use NONE by default.
+ *         <pre>
+ *         {@code
+ *         myContainer.setPlayerSelector(PlayerSelector.NONE)
+ *         }
+ *         </pre>
+ *
+ *         2. When an event occurs, provide a SinglePlayerSelector that'll use the desired
+ *         {@link ToroPlayer} instance. This is ideal to start a player on click event.
+ *         <pre>
+ *         {@code
+ *         myContainer.setPlayerSelector(new SinglePlayerSelector(myPlayer))
+ *         }
+ *         </pre>
+ *
+ */
+
+public class SinglePlayerSelector implements PlayerSelector {
+
+  ToroPlayer player;
+
+  public SinglePlayerSelector(ToroPlayer player) {
+    this.player = player;
+  }
+
+  @NonNull
+  @Override public Collection<ToroPlayer> select(@NonNull Container container, @NonNull List<ToroPlayer> items) {
+    ArrayList<ToroPlayer> toSelect = new ArrayList<>();
+    toSelect.add(player);
+    return toSelect;
+  }
+
+  @NonNull @Override public PlayerSelector reverse() {
+    return this;
+  }
+}


### PR DESCRIPTION
## Problem
There is no clear way of how to play single a video on demand in the RecyclerView using Toro.

## Solution
To create a new class that implements `PlayerSelector` to wrap the logic to execute players on demand.

## Usage
1. Set `Container`’s player selector to `NONE`

```java
myContainer.setPlayerSelector(PlayerSelector.NONE);
```

2. Create a `SinglePlayerSelector` on demand and assign it to `myContainer`. It will wrap `ToroPlayer` and allow `Container` to manage the player. Example:

```java
// Holder.java pseudo-code
public void myClickListener(ToroPlayer player) {
  SinglePlayerSelector = singlePlayerSelector = new SinglePlayerSelector(player);
  myContainer.setPlayerSelector(singlePlayerSelector);
}
```